### PR TITLE
Syntax change in docker command updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker build -t="$USER/mysql" .
 Run the mysql image
 
 ```bash
-docker run -name mysql -d sameersbn/mysql:latest
+docker run --name mysql -d sameersbn/mysql:latest
 ```
 
 You can access the mysql server as the root user using the following command:
@@ -98,7 +98,7 @@ sudo chcon -Rt svirt_sandbox_file_t /opt/mysql/data
 The updated run command looks like this.
 
 ```
-docker run -name mysql -d \
+docker run --name mysql -d \
   -v /opt/mysql/data:/var/lib/mysql sameersbn/mysql:latest
 ```
 

--- a/README.md
+++ b/README.md
@@ -208,5 +208,5 @@ docker pull sameersbn/mysql:latest
 - **Step 3**: Start the image
 
 ```bash
-docker run -name mysql -d [OPTIONS] sameersbn/mysql:latest
+docker run --name mysql -d [OPTIONS] sameersbn/mysql:latest
 ```


### PR DESCRIPTION
`-name=[...]` is now `--name=[...]`

   
    root@test:~# docker run -name mysql -d -v /opt/mysql/data:/var/lib/mysql sameersbn/mysql:latest
    Warning: '-n' is deprecated, it will be removed soon. See usage.
    invalid value "mysql" for flag -a: valid streams are STDIN, STDOUT and STDERR
    See 'docker run --help'.
    flag provided but not defined: -name
    See 'docker run --help'.
   
   
    root@test:~# docker run --name mysql -d -v /opt/mysql/data:/var/lib/mysql sameersbn/mysql:latest
    Unable to find image 'sameersbn/mysql:latest' locally
    latest: Pulling from sameersbn/mysql
   
