### PR TITLE
entrypoint.sh: add `MYSQL_CHARSET` and `MYSQL_COLLATION` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ The above command will create a user *dbuser* with the password *dbpass* and wil
 - If the user/database user already exists no changes are be made
 - If `DB_PASS` is not specified, an empty password will be set for the user
 
+By default the new database will be created with the `utf8` character set and `utf8_unicode_ci` collation. You may override these with the `MYSQL_CHARSET` and `MYSQL_COLLATION` variables.
+
+```bash
+docker run --name mysql -d \
+  -e 'DB_USER=dbuser' -e 'DB_PASS=dbpass' -e 'DB_NAME=dbname' \
+  -e 'MYSQL_CHARSET=utf8mb4' -e 'MYSQL_COLLATION=utf8_bin' \
+  quay.io/sameersbn/mysql:latest
+```
+
 # Creating remote user with privileged access
 
 To create a remote user with privileged access, you need to specify the `DB_REMOTE_ROOT_NAME` and `DB_REMOTE_ROOT_PASS` variables, eg.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,9 @@ DB_REMOTE_ROOT_NAME=${DB_REMOTE_ROOT_NAME:-}
 DB_REMOTE_ROOT_PASS=${DB_REMOTE_ROOT_PASS:-}
 DB_REMOTE_ROOT_HOST=${DB_REMOTE_ROOT_HOST:-"172.17.42.1"}
 
+MYSQL_CHARSET=${MYSQL_CHARSET:-"utf8"}
+MYSQL_COLLATION=${MYSQL_COLLATION:-"utf8_unicode_ci"}
+
 create_data_dir() {
   mkdir -p ${MYSQL_DATA_DIR}
   chmod -R 0700 ${MYSQL_DATA_DIR}
@@ -112,7 +115,7 @@ create_users_and_databases() {
       for db in $(awk -F',' '{for (i = 1 ; i <= NF ; i++) print $i}' <<< "${DB_NAME}"); do
         echo "Creating database \"$db\"..."
         mysql --defaults-file=/etc/mysql/debian.cnf \
-          -e "CREATE DATABASE IF NOT EXISTS \`$db\` DEFAULT CHARACTER SET \`utf8\` COLLATE \`utf8_unicode_ci\`;"
+          -e "CREATE DATABASE IF NOT EXISTS \`$db\` DEFAULT CHARACTER SET \`$MYSQL_CHARSET\` COLLATE \`$MYSQL_COLLATION\`;"
           if [ -n "${DB_USER}" ]; then
             echo "Granting access to database \"$db\" for user \"${DB_USER}\"..."
             mysql --defaults-file=/etc/mysql/debian.cnf \


### PR DESCRIPTION
There are edge cases when it would be useful to specify a non-default charset or collation on database creation.